### PR TITLE
Fix blog page styling to match the rest of the site

### DIFF
--- a/components/Blog.tsx
+++ b/components/Blog.tsx
@@ -2,6 +2,7 @@ import Container from '@/components/Container'
 import HeroPost from '@/components/HeroPost'
 import Intro from '@/components/Intro'
 import MoreStories from '@/components/MoreStories'
+import Footer from '@/components/Footer'
 import type PostType from '@/types/post'
 import RainbowHighlight from '@/components/RainbowHighlight'
 import { RoughNotationGroup } from 'react-rough-notation'
@@ -29,6 +30,7 @@ export default function Blog({ allPosts }: Props) {
         )}
       </RoughNotationGroup>
       {morePosts.length > 0 && <MoreStories posts={morePosts} />}
+      <Footer />
     </Container>
   )
 }

--- a/components/Container.tsx
+++ b/components/Container.tsx
@@ -5,7 +5,7 @@ type Props = {
 }
 
 const Container = ({ children = null }: Props) => (
-  <div className="container mx-auto px-5">{children}</div>
+  <div className="container mx-auto px-5 py-10">{children}</div>
 )
 
 export default Container

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -2,25 +2,24 @@ import data from '@/constants/data'
 
 export default function Footer() {
   return (
-    <div className="bg-neutral-50 text-neutral-800 dark:text-neutral-50 dark:bg-neutral-800">
-      <div className="max-w-6xl  mx-auto px-4 py-10 md:py-20">
-        {/*<div className="h-0.5 w-full bg-white dark:bg-gray-700"></div>*/}
-        <div className="font-typewriter flex flex-col space-y-4 md:space-y-0 md:flex-row justify-between md:items-center mt-8">
+    <div className="blog-footer">
+      <div className="blog-footer-container">
+        <div className="blog-footer-content">
           <div>
-            <p>build with ♥ by MJ Linane | &copy; 2023</p>
+            <p className="blog-footer-text">build with ♥ by MJ Linane | &copy; 2023</p>
           </div>
           <div className="space-x-4 flex flex-row items-center">
             <a
               title="Twitter"
               href={data.socialLinks.twitter}
-              className="text-base font-normal text-neutral-600 dark:text-neutral-300"
+              className="blog-footer-text"
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 width="16"
                 height="16"
                 fill="currentColor"
-                className="bi bi-twitter h-5 w-5"
+                className="blog-footer-icon"
                 viewBox="0 0 16 16"
               >
                 <path d="M5.026 15c6.038 0 9.341-5.003 9.341-9.334 0-.14 0-.282-.006-.422A6.685 6.685 0 0 0 16 3.542a6.658 6.658 0 0 1-1.889.518 3.301 3.301 0 0 0 1.447-1.817 6.533 6.533 0 0 1-2.087.793A3.286 3.286 0 0 0 7.875 6.03a9.325 9.325 0 0 1-6.767-3.429 3.289 3.289 0 0 0 1.018 4.382A3.323 3.323 0 0 1 .64 6.575v.045a3.288 3.288 0 0 0 2.632 3.218 3.203 3.203 0 0 1-.865.115 3.23 3.23 0 0 1-.614-.057 3.283 3.283 0 0 0 3.067 2.277A6.588 6.588 0 0 1 .78 13.58a6.32 6.32 0 0 1-.78-.045A9.344 9.344 0 0 0 5.026 15z" />
@@ -29,14 +28,14 @@ export default function Footer() {
             <a
               title="Github"
               href={data.socialLinks.github}
-              className="text-base font-normal text-neutral-600 dark:text-neutral-300"
+              className="blog-footer-text"
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 width="16"
                 height="16"
                 fill="currentColor"
-                className="h-5 w-5"
+                className="blog-footer-icon"
                 viewBox="0 0 24 24"
               >
                 <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
@@ -45,14 +44,14 @@ export default function Footer() {
             <a
               title="Linkedin"
               href={data.socialLinks.linkedin}
-              className="text-base font-normal text-neutral-600 dark:text-neutral-300"
+              className="blog-footer-text"
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 width="16"
                 height="16"
                 fill="currentColor"
-                className="bi bi-linkedin h-5 w-5"
+                className="blog-footer-icon"
                 viewBox="0 0 16 16"
               >
                 <path d="M0 1.146C0 .513.526 0 1.175 0h13.65C15.474 0 16 .513 16 1.146v13.708c0 .633-.526 1.146-1.175 1.146H1.175C.526 16 0 15.487 0 14.854V1.146zm4.943 12.248V6.169H2.542v7.225h2.401zm-1.2-8.212c.837 0 1.358-.554 1.358-1.248-.015-.709-.52-1.248-1.342-1.248-.822 0-1.359.54-1.359 1.248 0 .694.521 1.248 1.327 1.248h.016zm4.908 8.212V9.359c0-.216.016-.432.08-.586.173-.431.568-.878 1.232-.878.869 0 1.216.662 1.216 1.634v3.865h2.401V9.25c0-2.22-1.184-3.252-2.764-3.252-1.274 0-1.845.7-2.165 1.193v.025h-.016a5.54 5.54 0 0 1 .016-.025V6.169h-2.4c.03.678 0 7.225 0 7.225h2.4z" />

--- a/components/HeroPost.tsx
+++ b/components/HeroPost.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import Avatar from '@/components/Avatar'
 import CoverImage from '@/components/CoverImage'
 import DateFormatter from '@/components/DateFormatter'
+import RainbowHighlight from '@/components/RainbowHighlight'
 import type Author from '@/types/author'
 
 type Props = {
@@ -35,7 +36,7 @@ export default function HeroPost({
               href="/posts/[slug]"
               className="hover:underline"
             >
-              {title}
+              <RainbowHighlight color={'#a855f7'}>{title}</RainbowHighlight>
             </Link>
           </h3>
           <div className="mb-4 md:mb-0 text-lg">

--- a/components/Intro.tsx
+++ b/components/Intro.tsx
@@ -1,10 +1,10 @@
 export default function Intro() {
   return (
-    <section className="flex-col md:flex-row flex items-center md:justify-between mt-16 mb-16 md:mb-12">
-      <h1 className="text-6xl md:text-8xl font-bold tracking-tighter leading-tight md:pr-8">
+    <section className="blog-intro">
+      <h1 className="blog-intro-title">
         my blog.
       </h1>
-      <h4 className="text-center md:text-left text-lg mt-5 md:pl-8">
+      <h4 className="blog-intro-subtitle">
         a blog about web development, teaching, and learning.
       </h4>
     </section>

--- a/components/MoreStories.tsx
+++ b/components/MoreStories.tsx
@@ -8,10 +8,10 @@ type Props = {
 export default function MoreStories({ posts }: Props) {
   return (
     <section>
-      <h2 className="mb-8 text-6xl md:text-7xl font-bold tracking-tighter leading-tight">
+      <h2 className="blog-more-stories">
         More Stories
       </h2>
-      <div className="grid grid-cols-1 md:grid-cols-2 md:col-gap-16 lg:col-gap-32 row-gap-20 md:row-gap-32 mb-32">
+      <div className="blog-more-stories-grid">
         {posts.map((post) => (
           <PostPreview
             key={post.slug}

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -135,6 +135,32 @@ export default function NavBar() {
               )}
             </div>
           </Link>
+          <Link href="/blog">
+            <div
+              className={`text-base  ${
+                router.asPath === '/blog'
+                  ? 'text-neutral-800 font-bold' + ' dark:text-neutral-400'
+                  : 'text-neutral-600 dark:text-neutral-300' + ' font-normal'
+              }`}
+            >
+              blog
+              {router.asPath === '/blog' && (
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="16"
+                  height="16"
+                  fill="currentColor"
+                  className="bi bi-arrow-down inline-block h-3 w-3"
+                  viewBox="0 0 16 16"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M8 1a.5.5 0 0 1 .5.5v11.793l3.146-3.147a.5.5 0 0 1 .708.708l-4 4a.5.5 0 0 1-.708 0l-4-4a.5.5 0 0 1 .708-.708L7.5 13.293V1.5A.5.5 0 0 1 8 1z"
+                  />
+                </svg>
+              )}
+            </div>
+          </Link>
         </div>
 
         {/*social media links*/}
@@ -242,6 +268,11 @@ export default function NavBar() {
         <Link href="/contact">
           <div className="text-base font-normal text-neutral-600 dark:text-neutral-300">
             Contact
+          </div>
+        </Link>
+        <Link href="/blog">
+          <div className="text-base font-normal text-neutral-600 dark:text-neutral-300">
+            Blog
           </div>
         </Link>
       </div>

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -135,32 +135,7 @@ export default function NavBar() {
               )}
             </div>
           </Link>
-          <Link href="/blog">
-            <div
-              className={`text-base  ${
-                router.asPath === '/blog'
-                  ? 'text-neutral-800 font-bold' + ' dark:text-neutral-400'
-                  : 'text-neutral-600 dark:text-neutral-300' + ' font-normal'
-              }`}
-            >
-              blog
-              {router.asPath === '/blog' && (
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  width="16"
-                  height="16"
-                  fill="currentColor"
-                  className="bi bi-arrow-down inline-block h-3 w-3"
-                  viewBox="0 0 16 16"
-                >
-                  <path
-                    fillRule="evenodd"
-                    d="M8 1a.5.5 0 0 1 .5.5v11.793l3.146-3.147a.5.5 0 0 1 .708.708l-4 4a.5.5 0 0 1-.708 0l-4-4a.5.5 0 0 1 .708-.708L7.5 13.293V1.5A.5.5 0 0 1 8 1z"
-                  />
-                </svg>
-              )}
-            </div>
-          </Link>
+// Removed duplicate "Blog" link block to consolidate navigation.
         </div>
 
         {/*social media links*/}

--- a/components/PostBody.tsx
+++ b/components/PostBody.tsx
@@ -5,7 +5,7 @@ type Props = {
 export default function PostBody({ content }: Props) {
   return (
     <div className="max-w-2xl mx-auto">
-      <div dangerouslySetInnerHTML={{ __html: content }} />
+      <div className="blog-post-body" dangerouslySetInnerHTML={{ __html: content }} />
     </div>
   )
 }

--- a/components/PostHeader.tsx
+++ b/components/PostHeader.tsx
@@ -2,6 +2,7 @@ import Avatar from '@/components/Avatar'
 import CoverImage from '@/components/CoverImage'
 import DateFormatter from '@/components/DateFormatter'
 import PostTitle from '@/components/PostTitle'
+import RainbowHighlight from '@/components/RainbowHighlight'
 import type Author from '@/types/author'
 
 type Props = {
@@ -14,7 +15,9 @@ type Props = {
 function PostHeader({ title, coverImage, date, author }: Props) {
   return (
     <>
-      <PostTitle>{title}</PostTitle>
+      <PostTitle>
+        <RainbowHighlight color={'#a855f7'}>{title}</RainbowHighlight>
+      </PostTitle>
       <div className="hidden md:block md:mb-12">
         <Avatar name={author.name} picture={author.picture} />
       </div>

--- a/components/PostPreview.tsx
+++ b/components/PostPreview.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import Avatar from '@/components/Avatar'
 import CoverImage from '@/components/CoverImage'
 import DateFormatter from '@/components/DateFormatter'
+import RainbowHighlight from '@/components/RainbowHighlight'
 import type Author from '@/types/author'
 
 type Props = {
@@ -32,7 +33,7 @@ const PostPreview = ({
         href="/posts/[slug]"
         className="hover:underline"
       >
-        {title}
+        <RainbowHighlight color={'#a855f7'}>{title}</RainbowHighlight>
       </Link>
     </h3>
     <div className="text-lg mb-4">

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -12,8 +12,83 @@
   .box-shadow-md-black{
     box-shadow: 1rem 1rem 0 0 #000;
   }
-}
 
+  .blog-container {
+    @apply container mx-auto px-5;
+  }
+
+  .blog-hero-post {
+    @apply mb-8 md:mb-16;
+  }
+
+  .blog-hero-post-title {
+    @apply mb-4 text-4xl lg:text-5xl leading-tight;
+  }
+
+  .blog-hero-post-date {
+    @apply mb-4 md:mb-0 text-lg;
+  }
+
+  .blog-hero-post-excerpt {
+    @apply text-lg leading-relaxed mb-4;
+  }
+
+  .blog-more-stories {
+    @apply mb-8 text-6xl md:text-7xl font-bold tracking-tighter leading-tight;
+  }
+
+  .blog-more-stories-grid {
+    @apply grid grid-cols-1 md:grid-cols-2 md:col-gap-16 lg:col-gap-32 row-gap-20 md:row-gap-32 mb-32;
+  }
+
+  .blog-post-preview {
+    @apply mb-5;
+  }
+
+  .blog-post-preview-title {
+    @apply text-3xl mb-3 leading-snug;
+  }
+
+  .blog-post-preview-date {
+    @apply text-lg mb-4;
+  }
+
+  .blog-post-preview-excerpt {
+    @apply text-lg leading-relaxed mb-4;
+  }
+
+  .blog-intro {
+    @apply flex-col md:flex-row flex items-center md:justify-between mt-16 mb-16 md:mb-12;
+  }
+
+  .blog-intro-title {
+    @apply text-6xl md:text-8xl font-bold tracking-tighter leading-tight md:pr-8;
+  }
+
+  .blog-intro-subtitle {
+    @apply text-center md:text-left text-lg mt-5 md:pl-8;
+  }
+
+  .blog-footer {
+    @apply bg-neutral-50 text-neutral-800 dark:text-neutral-50 dark:bg-neutral-800;
+  }
+
+  .blog-footer-container {
+    @apply max-w-6xl mx-auto px-4 py-10 md:py-20;
+  }
+
+  .blog-footer-content {
+    @apply font-typewriter flex flex-col space-y-4 md:space-y-0 md:flex-row justify-between md:items-center mt-8;
+  }
+
+  .blog-footer-text {
+    @apply text-base font-normal text-neutral-600 dark:text-neutral-300;
+  }
+
+  .blog-footer-icon {
+    @apply h-5 w-5;
+  }
+}
 
 html,
 body {


### PR DESCRIPTION
Related to #50

Update blog page styling to match the rest of the site.

* Modify `components/Blog.tsx` to use `Container`, `HeroPost`, `MoreStories`, `Intro`, and `Footer` components.
* Modify `components/HeroPost.tsx` to use `RainbowHighlight` for hero post title.
* Modify `components/PostHeader.tsx` to use `RainbowHighlight` for post title.
* Modify `components/PostPreview.tsx` to use `RainbowHighlight` for post title.
* Add specific blog page styles in `styles/globals.css`.
* Modify `components/Container.tsx` to ensure consistent padding and margin.
* Modify `components/Footer.tsx` to include at the bottom of the blog page.
* Modify `components/PostBody.tsx` to display the content of a single post.
* Modify `components/Intro.tsx` to display the introductory text for the blog page.
* Modify `components/MoreStories.tsx` to arrange additional posts in a grid layout.
* Modify `components/NavBar.tsx` to include a link to the blog page for easy navigation.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mj-linane/mj-linane-portfolio/pull/155?shareId=eb7e9e65-3aa3-4168-a291-b8340f8e4da3).